### PR TITLE
Fix cookie not being set sometimes.

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -51,19 +51,17 @@ app.use(thisCookieSession);
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
-// Serving static resources
-app.use(express.static(path.join(__dirname, "assets")));
-
-// --------------------------
-// Routes
-app.get('/', function (req, res) {
+app.use(function (req, res, next) {
   if(req.session.isNew) {
     var userGuid = guid.raw();
     req.session.userId = userGuid;
   }
 
-  res.sendFile(path.join(__dirname, '/assets/index.html'));
+  next();
 });
+
+// Serving static resources
+app.use(express.static(path.join(__dirname, "assets")));
 
 // --------------------------
 // Socket.IO


### PR DESCRIPTION
So the user id was never showing up when I tested the application in Google Chrome.

At first I thought it was a chrome specific problem but the same issue occurred in Mozilla when running the application on a different computer. After throwing in a few watch points I realized that the custom middleware was never being called at all so userId was never being set on the session. After a little analysis it made sense. The staticfiles middleware doesn't call the next middleware in the chain, so the custom one was unreachable. What I don't get is why it ever worked at all. This commit fixes the problem by swapping the order that the middleware are loaded into express.
